### PR TITLE
Adding scripts and documentation to get failed jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+## Used to keep undesired files from this GitHub Repository
+
+# Mac auto-generated files
+.DS_Store
+
+# Excel Files created by `fme-rest-api-vs-tools/get-failed-jobs` script
+fme-rest-api-vs-tools/get-failed-jobs/*.xlsx

--- a/fme-rest-api-v3-tools/get-failed-jobs/README.md
+++ b/fme-rest-api-v3-tools/get-failed-jobs/README.md
@@ -1,0 +1,385 @@
+# Get Failed Jobs
+
+## Overview
+
+This collection of scripts is used to query [FME Flow REST API V3](http://asellus.dmz/fmerest/apidoc/v3/#) for failed jobs then will loop through all jobs creating an Excel workbook with related job information.
+
+> [!NOTE]
+> To use the FME Flow REST API V3 you will need to be connected to VPN (or VPN2) and have an account with access to use the API.
+> See the section [Requirements](#Requirements) below for more information on connecting and using FME Flow REST API V3.
+
+## Requirements
+
+- Python 3 and included libraries
+- Python additional library `xlsxwriter`
+- FME Flow REST API Token
+  - This can be generated from any page within [FME Flow REST API V3](http://asellus.dmz/fmerest/apidoc/v3/#)
+  - Access is restricted to VPN (or VPN2)
+  - To generate the token use the `Get Token` button to the top left of the screen
+    - This will require a valid Asellus FME Flow Account with permissions to API use
+  - The token only lasts an hour and will need to be refreshed after that time
+
+## Directory
+
+A brief description of the files included in this directory. To see detailed information refer to each files documentation and the [Process](#Process) section below.
+
+| Item              | Description                                                       |
+| ------------------| ----------------------------------------------------------------- |
+| `control.py`      | Handles configuration and flow of curating output.                |
+| `fme_flow_api.py` | Handles all calls to FME Flow REST API V3.                        |
+| `jobs.py`         | Handles creation of jobs in the format specified.                 |
+| `settings.py`     | Constants and global variables defined here.                      |
+| `utils.py`        | Common functions that may be used accross many different scripts. |
+| `README.md`       | This document                                                     |
+
+## Process
+
+> [!NOTE]
+> This section will go into the process of the scripts. If the scripts are updated it may be out of date.
+
+1. User starts script
+2. `control.py`s main() function hit
+   1. `settings.py` init() function called
+      1. Global variables set
+   2. logger is initilized and configured
+   3. (info level log) "Requesting failed jobs..."
+   4. `fme_flow_api.py`s get_failed() function is called. Results set as `fail_jobs`
+      1. Get first batch of failed jobs
+      2. While there are more jobs to process:
+         1. If this is the first batch of failed jobs set failed jobs to the dict of failed jobs
+         2. If this is not the first batch of failed jobs add all new jobs to failed jobs dict
+         3. Add the number of jobs requested to the offset
+         4. Get the next batch of jobs
+      3. Return the failed job dict
+  5. (info level log) "Failed jobs loaded."
+  6. Check the number of failed jobs in `fail_jobs` dict against total count of failed jobs
+     1. If the difference is more than 0 (warn level log) "Missing X failed jobs"
+  7. (info level log) "Configuring Output..."
+  8. build_output_dir(fail_jobs) is called. Return value set to `output`
+     1. For each failed job within fail_jobs:
+        1. Check if the start time and job id for the current failed job is already in the out dict. If it is:
+           1. Add to duplicated list
+           2. go to the next failed job
+        2. Compare the current failed jobs status message with the global status message (from `settings.py`). If they are the same flag that this is a no logs error
+        3. `jobs.py` build_job function called for current job. Returned value set to `job`
+           1. Create a dict with information passed in, see [Jobs](#Jobs) for more information on this process.
+        4. Add new object with key of failed job start time to the out dict
+        5. go to next failed job.
+     2. Check if duplicated list is empty. If it isnt:
+        1. (warn level log) "Duplicated failed jobs found:" with information on each duplicated job.
+     3. Return failed jobs out dict
+  9. (info level log) "Output Setup"
+  10. (info level log) "Getting Related Jobs..."
+  11. `fme_flow_api`s get_related_jobs() is called passing in `output`. Returned value is set to `related_jobs`
+      1. Request completed jobs from FME Flow REST API
+      2. While there are more jobs to parse:
+         1. Print the percentage complete
+         2. Get start and end times for current job
+         3. Loop through failed jobs in `out`
+            1. Get failed jobs start and end time
+            2. Check if the current job and the failed job are the same, if they are jump to the next job
+            3. If the current jobs start time is before the failed jobs end time and one of the following is true (the current jobs end time is after the failed jobs start time  or the current jobs start time and the failed jobs start time are the same)
+               1. Build the current job using `jobs.py` build_job() function (see step 8.3 for basic steps)
+               2. Add 1 to the `NUM_JOBS` of the failed jobs
+               3. Add the engine of the current job to the failed jobs `ENGINES`
+               4. Add the current job to the list of related jobs in `RELATED_JOBS`
+           4. Else if the engine name of the current job is the same as the failed job
+              1. Build a job for the current job using `jobs.py` build_job() function (see step 8.3 for basic steps)
+              2. If the failed jobs start time is after the current jobs end time and one of the following is true (the `PREVIOUS_JOB` has not been set or the `PREVIOUS_JOB`s time started is before the current jobs start time)
+                 1. Set the failed jobs `PREVIOUS_JOB` to the current job
+         4. Add the limit to the offset
+         5. Get another batch of jobs
+      3. Print the final progress bar
+      4. Return the `out` directory
+  12. (info level log) "Related Jobs Loaded."
+  13. Call clean_output(related_jobs). Save result as `cleaned`
+      1. Loop through all related jobs information in result
+         1. If the current failed job has nothing in `RELATED_JOBS` and nothing is set for `PREVIOUS_JOB`
+            1. remove from the related job dir and add to no_related_jobs list
+      2. Add no_related_job list as a value for root level key `FAILED_NO_CONCURRENT` in the related jobs dict
+      3. Return the cleaned related jobs dict
+  14. (info level log) "Writing to Excel..."
+  15. Call write_to_excel() passing in `cleaned`
+      1. Create a workbook called "FailedJobs.xlsx"
+      2. Add a sheet called "Failed Overview"
+      3. Add overview headers to "Failed Overview"
+      4. Add a sheet called "Details"
+      5. Add detail headers to "Details"
+      6. For every element in `cleaned`
+         1. Print progress bar
+         2. If the key is `FAILED_NO_CONCURRENT` and there are elements within the value
+            1. Add a new sheet called "Failed Jobs no Related Jobs"
+            2. Add detail headers to "Failed Jobs no Related Jobs"
+            3. Write each job within `FAILED_NO_CONCURRENT` to "Failed Jobs no Related Jobs" using function detail_write():
+               1. Loop through detailed headers list
+                  1. If the header is "Failed/Previous/Related"
+                     1. Write parameter `job_type`
+                     2. Go to next header
+                  2. If the header is "Failed Job ID"
+                     1. Write parameter `failed_job_id`
+                     2. Go to next header
+                  3. Get the header field value from `to_write` save as variable `data`
+                  4. If the field is a datetime type
+                     1. Convert the datetime object to `date` and `time` strings
+                     2. If the header is "Time Started"
+                        1. Write the `date` to the sheet
+                     3. Set the `time` to variable `data`
+                  5. Write `data` to the matching header cell
+            4. Go to next element
+         3. If the key is a list
+            1. Go to the next element
+         4. Get the failed job
+         5. Write failed job information to the "Failed Overview" sheet
+            1. Failed job ID
+            2. Repository
+            3. No log error flag
+            4. Start datetime date
+            5. Start datetime time
+            6. End datetime time
+            7. Number of jobs running concurrently
+         6. Write the failed job to "Details" using function detail_write()
+         7. Write the previous job to "Details" using function detail_write()
+         8. For every job within `RELATED_JOBS`:
+            1. Write the current job to "Deatils" using function detail_write()
+      7. Close the workbook
+      8. Print the final progress percentage
+  16. (info level log) "Complete."
+
+# Job Data from request
+
+Requests are returned with the following structure:
+
+{
+  'request': {
+    'publishedParameters': [{ "name": str, "raw": str }, ... ],
+    'workspacePath': str,
+    'TMDirectives': { "rtc": bool, "ttc": int, "description": str, "tag": str, "priority": int, "ttl": int }
+    },
+    'NMDirectives': { "directives": list, "successTopics": list, "failureTopics": list(str) },
+    "timeDelivered": datetime,
+    "workspace": str,
+    "numErrors": int,
+    "numLines": int,
+    "engineHost": str,
+    "timeQueued": datetime,
+    "cpuPct": float,
+    "description": str,
+    "timeStarted": datetime,
+    "repository": str,
+    "userName": str,
+    "result": {
+      "timeRequested": datetime, "requesterResultPort": int, "numFeaturesOutput": int, "requesterHost": str, "timeStarted": datetime, "id": int, "timeFinished": datetime, "priority": int, "statusMessage": str, "status": str
+    },
+    "cpuTime": int,
+    "sourceType": str,
+    "id": int,
+    "sourceName": str,
+    "timeFinished": datetime,
+    "engineName": str,
+    "numWarnings": int,
+    "timeSubmitted": datetime,
+    "elapsedTime": int,
+    "peakMemUsage": int,
+    "status": str
+}
+
+## Jobs
+
+Reviewing the information provided in the documentation within [FME Flow REST API V3](http://asellus.dmz/fmerest/apidoc/v3/#) the results are provided in a JSON structure:
+
+```
+{
+  "items": [{}, ..., {}],
+  "limit": int,
+  "offset": int,
+  "totalCount": int
+}
+```
+
+Because there are over 19 thousand completed jobs to parse at any given time the script uses a default 1000 limit to the request and uses the offset amount to query for additional jobs.
+
+### Items
+
+The list of objects within "items" from the API returns the following structure:
+
+```
+{
+  "id": int,
+  "cpuPct": int,
+  "cpuTime": int,
+  "description": string,
+  "elapsedTime": int,
+  "engineHost": string,
+  "engineName": string,
+  "numErrors": int,
+  "numLines": int,
+  "numWarnings": int,
+  "peakMemUsage": int,
+  "repository": string,
+  "request": {
+    "NMDirectives": {
+      "directives": [ {}, ..., {} ],
+      "failureTopics": [ string, ...],
+      "successTopics": [ string, ...]
+    },
+    "TMDirectives": {
+      "rtc": true,
+      "ttc": int,
+      "ttl": int,
+      "description": string,
+      "priority": int,
+      "tag": "string"
+    },
+    "publishedParameters": [ {}, ..., {} ],
+    "workspacePath": "string"
+  },
+  "result": {
+    "id": int,
+    "numFeaturesOutput": int,
+    "priority": int,
+    "requesterHost": string,
+    "requesterResultPort": int,
+    "resultDatasetDownloadUrl": string,
+    "status": string,
+    "statusMessage": string,
+    "timeFinished": string,
+    "timeRequested": string,
+    "timeStarted": "string"
+  },
+  "sourceID": string,
+  "sourceName": string,
+  "sourceType": string,
+  "status": string,
+  "timeDelivered": string,
+  "timeFinished": string,
+  "timeQueued": string,
+  "timeStarted": string,
+  "timeSubmitted": string,
+  "userName": string,
+  "workspace": "string"
+}
+```
+
+Some of these fields we expect to have no value, or values that are not useful to our search. See the structure below for information on what is kept or not for each job.
+
+```
+'request': {
+    'publishedParameters': {
+        'FME_AUTOMATION_NAME': str, # always keep
+    },
+    'workspacePath': str, # always keep
+    'TMDirectives': {
+        "rtc": bool, # include if not false
+        "ttc": int, # include if not -1
+        "description": str, # include if not ""
+        "tag": str, # include if not "Default"
+        "priority": int, # include if not -1
+        "ttl": int # include if not -1
+    },
+    'NMDirectives': {
+        "directives": list, # include if not []
+        "successTopics": list, # include if not []
+    },
+    "timeDelivered": datetime, # include if it is different that time finished
+    "workspace": str, # always keep
+    "numErrors": int, # always keep
+    "numLines": int, # always keep
+    "engineHost": str, # include if not "localhost"
+    "timeQueued": datetime, # include if it is different than time started
+    "cpuPct": float, # always keep
+    "description": str, # include if not ""
+    "timeStarted": datetime, # keep, should be the same as time queued, time requested, and inner time started
+    "repository": str, # always keep
+    "result": {
+      "timeRequested": datetime, # include if it is different than time started
+      "requesterResultPort": int, # include if not -1
+      "numFeaturesOutput": int, # always keep
+      "requesterHost": str, # include if not "142.34.140.19"
+      "timeStarted": datetime, # include if it is different than time started
+      "id": int, # include if not same as outer ID
+      "timeFinished": datetime, # include if it is different that time finished (outer)
+      "priority": int, # include if not -1
+      "statusMessage": str, # always keep
+    },
+    "cpuTime": int, # always keep
+    "sourceType": str, # always keep
+    "id": int, # always keep
+    "sourceName": str, # always keep
+    "timeFinished": datetime, # include. Checks to see if timeSubmitted, request.timeFinished, timeDelivered are the same
+    "engineName": str, # always keep
+    "numWarnings": int, # always keep
+    "timeSubmitted": datetime, # include if it is different that time finished
+    "elapsedTime": int, # always keep
+    "peakMemUsage": int, # always keep
+    "status": str # always keep
+  }
+```
+
+## Output
+
+The worksheet that is created will always at minimum have two sheets `Overview` and `Failed Overview`. If there are any failed jobs that have no related or previous jobs included in their object a third sheet `Failed Jobs no Related Jobs` will be created.
+
+### Headers
+
+#### `Failed Overview` and `Failed Jobs no Related Jobs` Sheets
+
+"Job ID",
+"Failed Job ID",
+'Status',
+'Failed/Previous/Related',
+'Engine Name',
+'Date',
+'Time Started',
+'Time Finished',
+'Elapsed Time',
+'CPU Time',
+'CPU Percent',
+'Peak Memory Usage',
+'Repository',
+'Number Errors',
+'Number Warnings',
+'Number Lines',
+'Workspace',
+'Workspace Path',
+'Source Type',
+'Source Name',
+'Engine Host',
+'Description',
+'Result: ID',
+'User Name',
+'Published Parameters: KIRK_JOBLABEL',
+'Published Parameters: KIRK_JOBID',
+'Published Parameters: FME_AUTOMATION_NAME',
+'Published Parameters: KIRK_DEST_DB_KEY_OVERRIDE',
+'NM Directives: Directives',
+'NM Directives: Success Topics',
+'NM Directives: Failure Topics',
+'TM Directives: RTC',
+'TM Directives: TTC',
+'TM Directives: Description',
+'TM Directives: Tag',
+'TM Directives: Priority',
+'TM Directives: TTL',
+'Result: Requester Result Port',
+'Result: Number Features Output',
+'Result: Requester Host',
+'Result: Priority',
+'Result: Status Message',
+'Result: Status',
+'Time Queued',
+'Result: Time Requested',
+'Time Submitted',
+'Result: Time Started',
+'Time Delivered',
+'Result: Time Finished'
+
+#### `Overview` Sheet
+
+"Failed Job ID",
+"Repository",
+"No Log Error",
+"Date",
+"Start Time",
+"End Time",
+"Number of Jobs Running",
+"Number of KIRK Jobs Running"

--- a/fme-rest-api-v3-tools/get-failed-jobs/README.md
+++ b/fme-rest-api-v3-tools/get-failed-jobs/README.md
@@ -11,13 +11,24 @@ This collection of scripts is used to query [FME Flow REST API V3](http://asellu
 ## Requirements
 
 - Python 3 and included libraries
+  - To install Python 3 follow the required process within [Python Downloads](https://www.python.org/downloads/)
+  - To set your environment correctly consider following the steps within [BeginnersGuide/Documentation](https://wiki.python.org/moin/BeginnersGuide/Download)
+  - Take note of your Python Command (Eg. `python3`)
 - Python additional library `xlsxwriter`
+  - To install this follow the required steps within [Getting Started with XlsxWriter](https://xlsxwriter.readthedocs.io/getting_started.html)
 - FME Flow REST API Token
   - This can be generated from any page within [FME Flow REST API V3](http://asellus.dmz/fmerest/apidoc/v3/#)
   - Access is restricted to VPN (or VPN2)
   - To generate the token use the `Get Token` button to the top left of the screen
     - This will require a valid Asellus FME Flow Account with permissions to API use
   - The token only lasts an hour and will need to be refreshed after that time
+
+## To Run
+
+1. Complete the steps in [Requirements](#Requirements)
+2. Navigate to this folder on your environment
+3. Run the script with your Python command
+   `python3 control.py`
 
 ## Directory
 

--- a/fme-rest-api-v3-tools/get-failed-jobs/control.py
+++ b/fme-rest-api-v3-tools/get-failed-jobs/control.py
@@ -1,0 +1,276 @@
+"""
+Used to query for all failed jobs to build an Excel workbook of information on those jobs.
+"""
+import logging
+from datetime import datetime
+import xlsxwriter
+import settings
+import fme_flow_api as fme_api
+import utils
+import jobs
+
+def build_output_dir(failed):
+    """
+    Loops through all failed jobs to create a dictionary to hold the jobs that were running at
+    the same time and the job that was running on the same engine before the failed job started.
+
+    Parameters:
+      failed (list): list of failed jobs from FME Flow REST API
+
+    Returns:
+      out (dict): Elements stored based on their start time. Has the following structure:
+          {
+          START_TIME_1: {
+            "START_TIME": datetime object of failed job's start time,
+            "END_TIME": datetime object of failed job's end time,
+            "REPO": string of failed job's repository,
+            "NUM_JOBS": int count of jobs that were running at the same time as the failed job,
+            "NO_LOG": bool indicating if the failed job has no logs,
+            "ENGINES": list of engines that were running while the failed job was running,
+            "FAILED_JOB": job information for failed job,
+            "RELATED_JOBS": list of job's that were running while the failed job was running,
+            "PREVIOUS_JOB": job information for previous job
+            }
+          ...,
+          {START_TIME_N: {} }
+          }
+    """
+    out = {}
+    dup = []
+
+    # loop through failed jobs
+    for failed_job in failed['items']:
+        no_logs = False
+        # get the start time as a string
+        start = failed_job['result']['timeStarted']
+
+        # check if the time is already in the dict, and if the ids are the same
+        # we have a duplicated failed job. Add duplication to dup list
+        if start in out and failed_job['id'] == out[start]['FAILED_JOB']['Job ID']:
+            duplicated_failed = (failed_job, out[start]['FAILED_JOB'])
+            dup.append(duplicated_failed)
+            continue
+
+        # compare the status message from this job to the error message we are expecting from
+        # the no log failures. If they match set no_logs to True
+        result_status_message = failed_job['result']['statusMessage'][:61]
+        no_log_err = settings.const['result']['statusMessage'][:61]
+        if result_status_message == no_log_err:
+            no_logs = True
+
+        # build the job dict based on the information we want
+        job = jobs.build_job(failed_job)
+        failed_repo = job['Repository']
+        kirk_job = 0
+        if failed_repo == "KIRK":
+            kirk_job = 1
+        out[start] = {
+            "START_TIME": utils.str_to_datetime(start),
+            "END_TIME": utils.str_to_datetime(failed_job['timeFinished']),
+            "REPO": failed_repo,
+            "NUM_JOBS": 1,
+            "NO_LOG": no_logs,
+            "ENGINES": [failed_job['engineName']],
+            "NUM_KIRK_JOBS": kirk_job,
+            "FAILED_JOB": job,
+            "RELATED_JOBS": [],
+            "PREVIOUS_JOB": None
+        }
+
+    # If there were any duplicated failed jobs report them
+    if len(dup) > 0:
+        logging.warning("Duplicated failed jobs found:")
+        for cur_dup in dup:
+            logging.warning("""  %s\n  - Failed Job: %s, \n  - Existing Job: %s\n""",
+                           cur_dup[0]['result']['timeStarted'],
+                           cur_dup[0]['id'],
+                           cur_dup[1]['id'])
+
+    return out
+
+def clean_output(result):
+    """
+    Takes the dictionary of related jobs and reformats it so it is easier to see which have related
+    jobs. new_dict["FAILED_NO_CONCURRENT"] will be empty if all jobs have related jobs.
+
+    Parameters:
+      result (dict): dictionary with an entry for every failed job
+
+    Returns:
+      new_dict (dict): dictionary for failed jobs with related jobs prioritized, and a new section
+        for failed jobs with no jobs that ran at the same time listed below.
+    """
+    no_related_jobs = []
+    new_dict = {}
+
+    # loop through all objects in the dictionary
+    for job in result:
+        # If the related_jobs is empty and no previous job, add it to the no related jobs list
+        # Else add the object as is to the new dictionary
+        if result[job]['RELATED_JOBS'] == [] and result[job]['PREVIOUS_JOB'] is None:
+            no_related_jobs.append(result[job]["FAILED_JOB"])
+        else:
+            new_dict[job] = result[job]
+
+    new_dict["FAILED_NO_CONCURRENT"] = no_related_jobs
+
+    return new_dict
+
+def detail_write(sheet, row, failed_job_id, headers, to_write, job_type):
+    """
+    Standard write function for the rows within the details tab. Because we are writing to the
+    workbook directly we dont need to return anything.
+
+    Parameters:
+      sheet (xlsxwriter workbook sheet): Sheet to write information to
+      row (int): row to write to on sheet
+      failed_job_id (string): represents the Job ID of the failed job
+      headers ():
+      to_write ():
+      job_type ():
+    """
+    for col in headers:
+        if col == "Failed/Previous/Related":
+            sheet.write(row, headers.index(col), job_type)
+            continue
+        elif col == "Failed Job ID":
+            sheet.write(row, headers.index(col), failed_job_id)
+            continue
+        data = to_write.get(col)
+        if isinstance(data, datetime):
+            date, time = (data.strftime("%b %d, %y"), data.strftime("%I:%M:%S%p"))
+            if col == "Time Started":
+                # write the date at the same time as the time started
+                sheet.write(row, headers.index("Date"), date)
+            data = time
+        sheet.write(row, headers.index(col), data)
+
+def write_to_excel(obj):
+    """
+    Given the object with failed jobs and their related jobs create and write to a new Excel
+    sheet. There will always be at least two sheets created in the Excel file "Failed Overview"
+    and "Details". If there are any values for the key `FAILED_NO_CONCURRENT` a third sheet will
+    be added - "Failed Jobs no Related Jobs".
+
+    Parameters:
+      obj (dict): failed jobs dictionary with included related and previous job objects.
+    """
+    counter = 0
+    total = len(obj)
+
+    wb = xlsxwriter.Workbook("FailedJobs.xlsx")
+
+    overview = wb.add_worksheet("Failed Overview")
+    overview_row = 0
+    overview_headers = settings.headers['overview']
+    for ovw_col_num, ovw_header in enumerate(overview_headers):
+        overview.write(overview_row, ovw_col_num, ovw_header)
+    overview_row += 1
+
+    details = wb.add_worksheet("Details")
+    details_row = 0
+    detail_headers = settings.headers['detailed']
+    for det_col_num, det_header in enumerate(detail_headers):
+        details.write(details_row, det_col_num, det_header)
+    details_row += 1
+
+    for date_time in obj:
+        utils.print_percentage(counter, total=total)
+        counter += 1
+
+        if date_time == "FAILED_NO_CONCURRENT" and len(obj[date_time]) > 0:
+            no_rel = wb.add_worksheet("Failed Jobs no Related Jobs")
+            no_rel_row = 0
+            for no_rel_col, det_header in enumerate(detail_headers):
+                no_rel.write(no_rel_row, no_rel_col, det_header)
+
+            no_rel_row += 1
+            for job in obj[date_time]:
+                detail_write(no_rel, no_rel_row, "N/A", detail_headers, job, "Failed")
+            continue
+        if isinstance(obj[date_time], list):
+            continue
+
+        failed_job_id = obj[date_time]["FAILED_JOB"]["Job ID"]
+
+        # write to the overview page
+        overview.write(overview_row, overview_headers.index("Failed Job ID"),\
+                       failed_job_id)
+        overview.write(overview_row, overview_headers.index("Repository"),\
+                       obj[date_time]["REPO"])
+        overview.write(overview_row, overview_headers.index("No Log Error"),\
+                       obj[date_time]["NO_LOG"])
+        overview.write(overview_row, overview_headers.index("Date"),\
+                       obj[date_time]["START_TIME"].strftime("%b %d, %y"))
+        overview.write(overview_row, overview_headers.index("Start Time"),\
+                       obj[date_time]["START_TIME"].strftime("%I:%M:%S%p"))
+        overview.write(overview_row, overview_headers.index("End Time"),\
+                       obj[date_time]["END_TIME"].strftime("%I:%M:%S%p"))
+        overview.write(overview_row, overview_headers.index("Total Jobs Running"),\
+                       obj[date_time]["NUM_JOBS"])
+        overview.write(overview_row, overview_headers.index("Number of KIRK Jobs Running"),\
+                       obj[date_time]["NUM_KIRK_JOBS"])
+        overview_row += 1
+
+        # add failed job to details
+        detail_write(details, details_row, failed_job_id, detail_headers,\
+                     obj[date_time]["FAILED_JOB"], "Failed")
+        details_row += 1
+
+        # add previous job to details
+        detail_write(details, details_row, failed_job_id, detail_headers,\
+                     obj[date_time]["PREVIOUS_JOB"], "Previous")
+        details_row += 1
+
+        # loop through related jobs adding each
+        for job in obj[date_time]["RELATED_JOBS"]:
+            detail_write(details, details_row, failed_job_id, detail_headers, job, "Related")
+            details_row += 1
+
+    wb.close()
+    print(f"[{'#'*settings.terminal_width}] 100.00%", flush=True)
+
+def main():
+    """
+    Works through a file of failed jobs and gathers information on jobs that were running at
+    the same time on other engines, and the job that previously ran on the same engine.
+    Writes output to an Excel file "FailedJobs.xlsx". As the jobs are being processed info logs
+    are printed to console and 2 progress bars will display.
+    """
+    # set up global variables
+    settings.init()
+
+    # set up logging
+    log = logging.getLogger(__name__)
+    logging.basicConfig(format='%(levelname)s: %(message)s', level="INFO")
+
+    log.info("Requesting failed jobs...")
+
+    # read the failed jobs
+    fail_jobs = fme_api.get_failed()
+    log.info("Failed jobs loaded.")
+
+    # check the reported total number of failed jobs, compare the the number of failed jobs we hace
+    missing_jobs = fail_jobs['totalCount'] - len(fail_jobs['items'])
+    if missing_jobs > 0:
+        # if we are mising any report it
+        log.warning("Missing %s failed jobs", missing_jobs)
+
+    # Set up a dictionary to hold the jobs that were running at the same time
+    log.info("Configuring Output...")
+    output = build_output_dir(fail_jobs)
+    log.info("Output Setup")
+
+    # Parse related jobs and add to the output
+    log.info("Getting Related Jobs...")
+    related_jobs = fme_api.get_related_jobs(output)
+    log.info("Related Jobs Loaded.")
+
+    cleaned = clean_output(related_jobs)
+
+    log.info("Writing to Excel...")
+    write_to_excel(cleaned)
+    log.info("Complete.")
+
+if __name__ == "__main__":
+    main()

--- a/fme-rest-api-v3-tools/get-failed-jobs/fme_flow_api.py
+++ b/fme-rest-api-v3-tools/get-failed-jobs/fme_flow_api.py
@@ -1,0 +1,137 @@
+"""
+Holding all functions that connect to the FME Flow API.
+
+Imports:
+  sys: Handles exiting the program in the case of unexpected behaviour
+  requests: Handles request to FME Flow REST API
+  utils: Custom Python file with common functions
+  settings: Custom Python file with constants
+  jobs: Custom Python file to create job objects
+"""
+import sys
+import requests
+import utils
+import settings
+import jobs
+
+def get_jobs(limit, offset, failed=False):
+    """
+    Fetch another batch of jobs from the FME API.
+    If failed is set this will only return failed jobs.
+
+    Parameters:
+      limit (int): The number of jobs to fetch.
+      offset (int): The offset for pagination.
+      failed (bool): Flag for requesting failed jobs. Default is False
+
+    Returns:
+      res.json() (dict): result of FME Flow REST API call, unpacked from json to a dict
+    """
+    token = utils.check_token()
+
+    state = ""
+    if failed:
+        state = "completedState=failed&"
+    temp_req = settings.api_token + f'{state}limit={limit}&offset={offset}'
+    headers = {
+        'Authorization': f'fmetoken token={token}'
+    }
+    try:
+        # try to request jobs. If an error occurs or the timeout is hit script will exit.
+        res = requests.get(url=temp_req, headers=headers, timeout=3)
+    except requests.exceptions.RequestException as e:
+        print(f"Error fetching jobs: {e}")
+        sys.exit(1)
+    if res.status_code != 200:
+        print(f"Failed to fetch jobs: {res.status_code} - {res.text}")
+        sys.exit(1)
+    return res.json()
+
+def get_failed():
+    """
+    Used to query FME Flow REST API for failed jobs, paginating results and storeing them within
+    a dictionary to be parsed.
+
+    Returns:
+      failed (dict): Dictionary holding all results of failed job request, if there are more than
+        limit a new request is made and the results are added as required.
+    """
+    limit = 1000
+    offset = 0
+    jobs_res = get_jobs(limit, offset, failed=True)
+    failed = {}
+
+    while jobs_res['limit'] > offset:
+        if offset != 0:
+            for job in jobs_res['items']:
+                failed['items'].append(job)
+        else:
+            failed = dict(jobs_res)
+
+        offset += limit
+        get_jobs(limit, offset, failed=True)
+    return failed
+
+def get_related_jobs(out):
+    """
+    Used to request for all completed jobs, comparing each to the list of failed jobs. If the job
+    does not have the same ID as a failed job checks start to see if the current job is related
+    to any of the failed jobs. The first check determines if the current job falls within the start
+    and end time range of a faild job its information is added to the failed jobs `RELATED_JOBS`
+    list. If the job ran on the same engine as a failed job, the end time of current job is before
+    the endtime of the failed job and one of the following is true:
+      no previous job is set or the start time of this job is more recent than the set previous job
+    then the current job is set as the failed jobs `PREVIOUS_JOB`.
+    Requests are made to FME Flow REST API until all jobs have been parsed.
+
+    Parameters:
+      out (dict): precreated stucture of failed jobs
+
+    Returns:
+      out (dict): stucture of failed jobs with additional information on related and previous jobs
+    """
+    limit = 1000
+    offset = 0
+    jobs_res = get_jobs(limit, offset)
+    total_jobs = jobs_res.get('totalCount')
+
+    # loop through all completed jobs, sending new requests as required
+    while total_jobs > offset:
+        # update progress bar
+        utils.print_percentage(offset, total=total_jobs)
+        # for each completed job in the burrent batch
+        for request in jobs_res['items']:
+            # get current jobs start and end times
+            req_start_datetime = utils.str_to_datetime(request['timeStarted'])
+            req_end_datetime = utils.str_to_datetime(request['timeFinished'])
+            # loop through each failed job
+            for failed_job in out:
+                # get failed jobs start and end times
+                fail_end_time = out[failed_job]['END_TIME']
+                fail_start_time = out[failed_job]['START_TIME']
+                if out[failed_job]['FAILED_JOB']['Job ID'] == request['id']:
+                    # the current job is a failed job
+                    continue
+                # A job is related if its start time is before the failed jobs end time
+                #   and the job's end time is after the failed jobs start time
+                if (req_start_datetime < fail_end_time and \
+                   req_end_datetime >= fail_start_time) or \
+                   req_start_datetime == fail_start_time:
+                    related_job = jobs.build_job(request)
+                    out[failed_job]['NUM_JOBS'] += 1
+                    out[failed_job]['ENGINES'].append(request['engineName'])
+                    out[failed_job]['RELATED_JOBS'].append(related_job)
+                    if related_job['Repository'] == "KIRK":
+                        out[failed_job]['NUM_KIRK_JOBS'] += 1
+                elif out[failed_job]['FAILED_JOB']['Engine Name'] == request['engineName']:
+                    test_job = jobs.build_job(request)
+                    if fail_start_time > test_job['Time Finished'] and \
+                       (out[failed_job]['PREVIOUS_JOB'] is None or \
+                        out[failed_job]['PREVIOUS_JOB']['Time Started'] < test_job['Time Started']):
+                        out[failed_job]['PREVIOUS_JOB'] = test_job
+
+        offset += limit
+        jobs_res = get_jobs(limit, offset)
+
+    print(f"[{'#'*settings.terminal_width}] 100.00%", flush=True)
+    return out

--- a/fme-rest-api-v3-tools/get-failed-jobs/jobs.py
+++ b/fme-rest-api-v3-tools/get-failed-jobs/jobs.py
@@ -1,0 +1,267 @@
+"""
+Handles the creation of job objects from raw FME Flow REST API requests.
+
+Imports:
+  utils: custom Python file with common functions
+  settings: custom Python file with constants
+"""
+import utils
+import settings
+
+def build_nmd(in_obj):
+    """
+    Checks values of in_obj for unexpected values. If any are found they are unpacked and
+    added to the return list to be added to the job information.
+
+    Parameters:
+      in_obj (dict): NMDirectives object returned from FME Flow API request.
+
+    Returns:
+      temp_nm (list[tuple]): unpacked key value pairs from all lists within in_obj.
+          If the key does not exist no tuple is added for that value.
+    """
+    temp_nm = []
+
+    if in_obj.get("directives"):
+        temp_nm.append(("NM Directives: Directives", str(in_obj["directives"])))
+    if in_obj.get("successTopics"):
+        temp_nm.append(("NM Directives: Success Topics", str(in_obj["successTopics"])))
+    if in_obj.get("failureTopics"): # != settings.const['NMDirectives']['failureTopics']:
+        temp_nm.append(("NM Directives: Failure Topics", str(in_obj["failureTopics"])))
+
+    return temp_nm
+
+def build_tmd(in_obj):
+    """
+    Checks values of in_obj for unexpected values. If any are found they are unpacked and
+    added to the return list to be added to the job information.
+
+    Parameters:
+      in_obj (dict): TMDirectives object returned from FME Flow API request.
+
+    Returns:
+      temp_nm (list[tuple]): unpacked key value pairs from all lists within in_obj.
+          If the key does not exist or if it matches the default value for its type
+          no tuple is added for that value.
+    """
+    temp_tm = []
+
+    rtc = in_obj.get('rtc')
+    if rtc != settings.const['TMDirectives']['rtc']:
+        temp_tm.append(('TM Directives: RTC', rtc))
+
+    ttc = in_obj.get('ttc')
+    if ttc != settings.const['TMDirectives']['ttc']:
+        temp_tm.append(('TM Directives: TTC', ttc))
+
+    desc = in_obj.get('description')
+    if desc != settings.const['TMDirectives']['description']:
+        temp_tm.append(('TM Directives: Description', desc))
+
+    tag = in_obj.get('tag')
+    if tag != settings.const['TMDirectives']['tag']:
+        temp_tm.append(('TM Directives: Tag', tag))
+
+    priority = in_obj.get('priority')
+    if priority != settings.const['TMDirectives']['priority']:
+        temp_tm.append(('TM Directives: Priority', priority))
+
+    ttl = in_obj.get('ttl')
+    if ttl != settings.const['TMDirectives']['ttl']:
+        temp_tm.append(('TM Directives: TTL', ttl))
+
+    return temp_tm
+
+def build_res(in_obj):
+    """
+    Checks values of in_obj for unexpected values. If any are found they are unpacked and
+    added to the return list to be added to the job information.
+
+    Parameters:
+      in_obj (dict): NMDirectives object returned from FME Flow API request.
+
+    Returns:
+      res (list[tuple]): unpacked key value pairs from all lists within in_obj.
+          If the key does not exist or if it matches the default value for its type
+          no tuple is added for that value.
+    """
+    res = []
+
+    res_port = in_obj.get('requesterResultPort')
+    if res_port != settings.const['result']['requesterResultPort']:
+        res.append(("Result: Requester Result Port", res_port))
+
+    feat_out = in_obj.get("numFeaturesOutput")
+    if feat_out: # != settings.const['result']['numFeaturesOutput']:
+        res.append(("Result: Number Features Output", feat_out))
+
+    req_host = in_obj.get("requesterHost")
+    if req_host != settings.const['result']['requesterHost']:
+        res.append(("Result: Requester Host", req_host))
+
+    priority = in_obj.get("priority")
+    if priority != settings.const['result']['priority']:
+        res.append(("Result: Priority", priority))
+
+    stat_message = in_obj.get("statusMessage")
+    if stat_message: # != settings.const['result']['statusMessage']:
+        res.append(("Result: Status Message", stat_message))
+
+    status = in_obj.get("status")
+    if status:
+        res.append(("Result: Status", status))
+
+    return res
+
+def get_pub_params(obj, name_li):
+    """
+    Given an object and a name list look through the object and return a new object with
+    the name value pairs.
+
+    Parameters:
+      obj (dict): object with values to be unpacked
+      name_li (list): list of keys that we are looking for
+
+    Returns:
+      ret (list): list of tuples representing values from obj that match keys within name_li
+    """
+    ret = []
+    for param in obj:
+        if param["name"] in name_li:
+            ret.append(("Published Parameters: " + param["name"], param["raw"]))
+
+    return ret
+
+def build_job(obj):
+    """
+    Given a job object create a new object holding only the necessary information
+    See README for more information on typical requests and how they are returned.
+
+    Parameters:
+      obj (dict): raw request data from FME Flow REST API. Detailed information on the structure
+          can be found in this directories README.md.
+
+    Returns:
+      job_dir (dict): Unpacked, sanitized information from obj
+    """
+    # base information we always want to keep.
+    job_dir = {}
+
+    if obj.get("id"):
+        job_dir['Job ID'] = obj['id']
+    if obj.get('engineName'):
+        job_dir['Engine Name'] = obj['engineName']
+    if obj.get('timeStarted'):
+        job_dir['Time Started'] = utils.str_to_datetime(obj['timeStarted'])
+    if obj.get('timeFinished'):
+        job_dir['Time Finished'] = utils.str_to_datetime(obj['timeFinished'])
+    if obj.get('elapsedTime'):
+        job_dir['Elapsed Time'] = obj['elapsedTime']
+    if obj.get('cpuTime'):
+        job_dir['CPU Time'] = obj['cpuTime']
+    if obj.get('cpuPct'):
+        job_dir['CPU Percent'] = obj['cpuPct']
+    if obj.get('peakMemUsage'):
+        job_dir['Peak Memory Usage'] = obj['peakMemUsage']
+    if obj.get('status'):
+        job_dir['Status'] = obj['status']
+    if obj.get('repository'): # != settings.const['repository']:
+        job_dir['Repository'] = obj['repository']
+    if obj.get('numErrors'):# != settings.const['numErrors']:
+        job_dir['Number Errors'] = obj['numErrors']
+    if obj.get('numWarnings'): # != settings.const['numWarnings']:
+        job_dir['Number Warnings'] = obj['numWarnings']
+    if obj.get('numLines'): # != settings.const['numLines']:
+        job_dir['Number Lines'] = obj['numLines']
+    if obj.get('workspace'): # != settings.const['workspace']:
+        job_dir['Workspace'] = obj['workspace']
+    if obj.get('workspacePath'):
+        #if obj['workspacePath'] != settings.const['workspacePath']:
+        job_dir['Workspace Path'] = obj['workspacePath']
+    if obj.get('sourceType'):
+        #if obj['sourceType'] != settings.const['sourceType']:
+        job_dir['Source Type'] = obj['sourceType']
+    if obj.get('sourceName'):
+        job_dir['Source Name'] = obj['sourceName']
+
+    engine_host = obj.get('engineHost')
+    if engine_host and engine_host != settings.const['engineHost']:
+        job_dir['Engine Host'] = engine_host
+
+    descp = obj.get('description')
+    if descp and descp != settings.const['description']:
+        job_dir['Description'] = descp
+
+    if obj['result'].get('id') != job_dir['Job ID']:
+        job_dir['Result: ID'] = obj['result']['id']
+
+    if obj.get('userName'): # != settings.const['userName']:
+        job_dir['User Name'] = obj['userName']
+
+    params = ['KIRK_JOBLABEL', 'KIRK_JOBID', 'FME_AUTOMATION_NAME', 'KIRK_DEST_DB_KEY_OVERRIDE']
+    pub_params = get_pub_params(obj['request']['publishedParameters'], params)
+    for param in pub_params:
+        job_dir[param[0]] = param[1]
+
+    if obj['request'].get('TMDirectives') != settings.const['TMDirectives']:
+        tmd = build_tmd(obj['request']['TMDirectives'])
+        for ele in tmd:
+            job_dir[ele[0]] = ele[1]
+
+    if obj['request'].get('NMDirectives') != settings.const['NMDirectives']:
+        nmd = build_nmd(obj['request']['NMDirectives'])
+        for ele in nmd:
+            job_dir[ele[0]] = ele[1]
+
+    if obj['result'] != settings.const['result']:
+        res = build_res(obj['result'])
+        for ele in res:
+            job_dir[ele[0]] = ele[1]
+
+    # checking the time started values to see if they need to be added
+    added_start_times = [job_dir.get('Time Started')]
+
+    time_queued = obj.get('timeQueued')
+    if time_queued:
+        time_queued = utils.str_to_datetime(time_queued)
+    if time_queued and time_queued not in added_start_times:
+        job_dir['Time Queued'] = time_queued
+        added_start_times.append(time_queued)
+
+    time_requested = obj['result'].get('timeRequested')
+    if time_requested:
+        time_requested = utils.str_to_datetime(time_requested)
+    if time_requested not in added_start_times:
+        job_dir['Result: Time Requested'] = time_requested
+        added_start_times.append(time_requested)
+
+    time_submitted = obj.get('timeSubmitted')
+    if time_submitted:
+        utils.str_to_datetime(time_submitted)
+    if time_submitted not in added_start_times:
+        job_dir['Time Submitted'] = time_submitted
+        added_start_times.append(time_submitted)
+
+    res_start = obj['result'].get('timeStarted')
+    if res_start:
+        res_start = utils.str_to_datetime(res_start)
+    if res_start not in added_start_times:
+        job_dir['Result: Time Started'] = res_start
+
+    # Checking the end times to see if they need to be added
+    added_fin_times = [job_dir.get('Time Finished')]
+
+    time_delivered = obj.get('timeDelivered')
+    if time_delivered:
+        time_delivered = utils.str_to_datetime(time_delivered)
+    if time_delivered not in added_fin_times:
+        job_dir['Time Delivered'] = time_delivered
+        added_fin_times.append(time_delivered)
+
+    res_time_fin = obj['result'].get('timeFinished')
+    if res_time_fin:
+        utils.str_to_datetime(res_time_fin)
+    if res_time_fin not in added_fin_times:
+        job_dir['Result: Time Finished'] = res_time_fin
+
+    return job_dir

--- a/fme-rest-api-v3-tools/get-failed-jobs/settings.py
+++ b/fme-rest-api-v3-tools/get-failed-jobs/settings.py
@@ -1,0 +1,131 @@
+"""
+Used to hold all "global" variables and constants that may be required by other scripts.
+"""
+import os
+
+def init():
+    """
+    Any global variables set here can be imported with this file, then accessed with dot notation
+
+    Globally acessable variables:
+      terminal_width (int): Determines the width of the terminal then divides by 2 and removes 7
+          character spaces to hold space for "[", "]", "%" and percentage numbers
+      api_token (str): Holds base path to FME Flow API
+      err_msg (str): Represents the error message that we see from "No Logs" FME Flow Job failures
+      const (dict): Object holding standard values that we want to remove from output information
+      headers (dict): Object holding 2 lists of detailed and overview page headers.
+    """
+    global terminal_width
+    terminal_width = (os.get_terminal_size().columns // 2) - 7
+
+    global api_token
+    api_token = 'http://asellus.dmz/fmerest/v3/transformations/jobs/completed?'
+
+    global err_msg
+    err_msg = 'INCLUDE -- failed to evaluate Python script '\
+    '`def ParamFunc():   import fme   from fmeFramework import KIRKParams   '\
+    'params = KIRKParams.KIRKParams(fme.macroValues)   fmc = params.getFieldMapCount()   '\
+    "print ('fmc is', fmc)   return fmc  value = ParamFunc() macroName = 'KIRK_FLDMAPCNT' "\
+    'if value == None:   return { macroName : u'' } else:   import six   try:     '\
+    'value = six.text_type(value)   except UnicodeDecodeError:     '\
+    "value = six.text_type(value, 'utf-8')   return { macroName : value } '"
+
+    global const
+    const = {
+        'publishedParameters': {
+            'KIRK_DEST_DB_KEY_OVERRIDE': "PRD"
+        },
+        'workspacePath': "\"KIRK/APP_KIRK__FGDB/APP_KIRK__FGDB.fmw\"",
+        'TMDirectives': {
+            "rtc": False,
+            "ttc": -1,
+            "description": "",
+            "tag": "Default",
+            "priority": -1,
+            "ttl": -1
+        },
+        'NMDirectives': {
+            "failureTopics": ["JOBSUBMITTER_ASYNC_JOB_FAILURE"]
+        },
+        "workspace": "APP_KIRK__FGDB.fmw",
+        "numErrors": 0,
+        "numLines": 0,
+        "engineHost": "localhost",
+        "description": "",
+        "repository": "KIRK",
+        "userName": "REPLICAT",
+        "result": {
+          "requesterResultPort": -1,
+          "numFeaturesOutput": 0,
+          "requesterHost": "142.34.140.19",
+          "priority": -1,
+          "statusMessage": err_msg
+        },
+        "sourceType": "SCHEDULES",
+        "numWarnings": 0
+      }
+
+    global headers
+    headers = {
+        "detailed": [
+          "Job ID",
+          "Failed Job ID",
+          'Status',
+          'Failed/Previous/Related',
+          'Engine Name',
+          'Date',
+          'Time Started',
+          'Time Finished',
+          'Elapsed Time',
+          'CPU Time',
+          'CPU Percent',
+          'Peak Memory Usage',
+          'Repository',
+          'Number Errors',
+          'Number Warnings',
+          'Number Lines',
+          'Workspace',
+          'Workspace Path',
+          'Source Type',
+          'Source Name',
+          'Engine Host',
+          'Description',
+          'Result: ID',
+          'User Name',
+          'Published Parameters: KIRK_JOBLABEL',
+          'Published Parameters: KIRK_JOBID',
+          'Published Parameters: FME_AUTOMATION_NAME',
+          'Published Parameters: KIRK_DEST_DB_KEY_OVERRIDE',
+          'NM Directives: Directives',
+          'NM Directives: Success Topics',
+          'NM Directives: Failure Topics',
+          'TM Directives: RTC',
+          'TM Directives: TTC',
+          'TM Directives: Description',
+          'TM Directives: Tag',
+          'TM Directives: Priority',
+          'TM Directives: TTL',
+          'Result: Requester Result Port',
+          'Result: Number Features Output',
+          'Result: Requester Host',
+          'Result: Priority',
+          'Result: Status Message',
+          'Result: Status',
+          'Time Queued',
+          'Result: Time Requested',
+          'Time Submitted',
+          'Result: Time Started',
+          'Time Delivered',
+          'Result: Time Finished',
+        ],
+        "overview": [
+          "Failed Job ID",
+          "Repository",
+          "No Log Error",
+          "Date",
+          "Start Time",
+          "End Time",
+          "Total Jobs Running",
+          "Number of KIRK Jobs Running"
+        ],
+    }

--- a/fme-rest-api-v3-tools/get-failed-jobs/utils.py
+++ b/fme-rest-api-v3-tools/get-failed-jobs/utils.py
@@ -1,0 +1,65 @@
+"""
+Holds functions that may be common to several scripts in the future, but current only serve
+as assists to the control.py script.
+
+Imports:
+  datetime - datetime, timedelta: used for date and time comparisons
+  settings: custom Python file used to store constants
+"""
+from datetime import datetime, timedelta
+import settings
+
+START_TIME = datetime.now()
+TOKEN = ''
+
+def check_token():
+    """
+    Check if the token is not set or if it is more than an hour old.
+    If either is true request a new token to be passed in via command line.
+
+    Returns:
+      token (str): user entered token stored as global variable
+    """
+    global TOKEN, START_TIME
+
+    if TOKEN == '' or datetime.now() > START_TIME + timedelta(minutes=55):
+        TOKEN = input("Please provide a valid FME token: ")
+        START_TIME = datetime.now()
+
+    return TOKEN
+
+def print_percentage(num, total):
+    """
+    Print a percentage progress indicator to the console.
+    This function will only work if the loop it is called in has no other print statements.
+
+    Parameters:
+      num (int): The current count.
+      total (int): The total count to reach.
+
+    Returns:
+      int: The terminal width used for the progress bar.
+    """
+    percentage = (num / total) * 100
+    term_complete = round((num / total) * settings.terminal_width)
+    term_uncomplete = settings.terminal_width - term_complete
+    percentage_str = f"{percentage:.2f}%"
+    term_str = f"[{'#' * term_complete}{'.' * term_uncomplete}]"
+    print(f"{term_str} {percentage_str}", end='\r', flush=True)
+
+def str_to_datetime(string_time):
+    """
+    Convert a FME date string to a datetime object.
+    Ex. string_time = "2025-01-02T03:04:05-" will return a date time object (date_time) with the
+    following values set:
+      Year: 2025, Month: January, Day: 2, Hour: 3, Minute: 4, Seconds: 5
+
+    Parameters:
+      string_time (str): The date string in the format 'YYYY-MM-DDTHH:MM:SS-'.
+
+    Returns:
+      date_time (datetime): datetime object representation of string_time
+    """
+    format_str = '%Y-%m-%dT%H:%M:%S%z'
+    date_time = datetime.strptime(string_time, format_str)
+    return date_time


### PR DESCRIPTION
# Overview

Adding the get failed and related job scripts and documentation. This work was completed in relation to [DPS-3689: KIRK and FME Framework Documentation](https://dpdd.atlassian.net/browse/DPS-3689) as well as [ETL Failures - No Logs](https://dpdd.atlassian.net/browse/DPS-3614). 

# Testing Instructions

1. Please read through the added `api-v3-tools/get-failed-jobs/README.md` to ensure information is correct and useful.
   1. The section `Requirements` within this document lists the required libraries, tokens, and environment to run the script
   2. Then follow the steps within the `To Run` section in the same document

You should see logs to the console, 2 progress bars, and a final log "INFO: Complete.". A new file `FailedJobs.xlsx` should appear in the directory you ran the script from.
Note that this process takes roughly 2-5 mins. 